### PR TITLE
Grab

### DIFF
--- a/coreAPI/src/java/net/java/games/input/Keyboard.java
+++ b/coreAPI/src/java/net/java/games/input/Keyboard.java
@@ -66,4 +66,8 @@ public abstract class Keyboard extends AbstractController {
 			return false;
 		return key.getPollData() != 0;
 	}
+
+	public boolean grab(){ return false; }
+
+	public boolean ungrab(){ return false;}
 } // class Keyboard

--- a/coreAPI/src/java/net/java/games/input/Mouse.java
+++ b/coreAPI/src/java/net/java/games/input/Mouse.java
@@ -183,4 +183,8 @@ public abstract class Mouse extends AbstractController {
 		return getComponent(Component.Identifier.Button._4);
 	}
 
+	public boolean grab(){ return false; }
+
+	public boolean ungrab(){ return false;}
+
 } // class Mouse

--- a/plugins/linux/build.xml
+++ b/plugins/linux/build.xml
@@ -56,6 +56,7 @@
 		<javah destdir="src/native">
             <classpath>
                 <pathelement location="classes"/>
+                <pathelement location="../../coreAPI/classes"/>
             </classpath>
 			<class name="net.java.games.input.LinuxEventDevice"/>
 			<class name="net.java.games.input.LinuxJoystickDevice"/>

--- a/plugins/linux/src/java/net/java/games/input/LinuxEnvironmentPlugin.java
+++ b/plugins/linux/src/java/net/java/games/input/LinuxEnvironmentPlugin.java
@@ -480,6 +480,43 @@ public final class LinuxEnvironmentPlugin extends ControllerEnvironment implemen
 		}
     }
 
+    /**
+     * Attempt to find devices using uinput used for forwarding events.
+     * TODO try to work this out!
+     */
+    /*
+    private final void enumerateUInputControllers(List controllers) {
+		final File dev = new File("/dev/uinput");
+		File[] event_device_files = listFilesPrivileged(dev, new FilenameFilter() {
+			public final boolean accept(File dir, String name) {
+				return name.startsWith("event");
+			}
+		});
+		if (event_device_files == null)
+			return;
+		for (int i = 0; i < event_device_files.length; i++) {
+			File event_file = event_device_files[i];
+			try {
+				String path = getAbsolutePathPrivileged(event_file);
+				LinuxEventDevice device = new LinuxEventDevice(path);
+				try {
+					Controller controller = createControllerFromDevice(device);
+					if (controller != null) {
+						controllers.add(controller);
+						devices.add(device);
+					} else
+						device.close();
+				} catch (IOException e) {
+					logln("Failed to create Controller: " + e.getMessage());
+					device.close();
+				}
+			} catch (IOException e) {
+				logln("Failed to open device (" + event_file + "): " + e.getMessage());
+			}
+		}
+    }
+    */
+
 	private final class ShutdownHook extends Thread {
 		public final void run() {
 			for (int i = 0; i < devices.size(); i++) {

--- a/plugins/linux/src/java/net/java/games/input/LinuxEventDevice.java
+++ b/plugins/linux/src/java/net/java/games/input/LinuxEventDevice.java
@@ -94,28 +94,6 @@ final class LinuxEventDevice implements LinuxDevice {
 	}
 
 	private final Controller.Type guessType() throws IOException {
-		Controller.Type type_from_usages = guessTypeFromUsages();
-		if (type_from_usages == Controller.Type.UNKNOWN)
-			return guessTypeFromComponents();
-		else
-			return type_from_usages;
-	}
-	
-	private final Controller.Type guessTypeFromUsages() throws IOException {
-		byte[] usage_bits = getDeviceUsageBits();
-		if (isBitSet(usage_bits, NativeDefinitions.USAGE_MOUSE))
-			return Controller.Type.MOUSE;
-		else if (isBitSet(usage_bits, NativeDefinitions.USAGE_KEYBOARD))
-			return Controller.Type.KEYBOARD;
-		else if (isBitSet(usage_bits, NativeDefinitions.USAGE_GAMEPAD))
-			return Controller.Type.GAMEPAD;
-		else if (isBitSet(usage_bits, NativeDefinitions.USAGE_JOYSTICK))
-			return Controller.Type.STICK;
-		else
-			return Controller.Type.UNKNOWN;
-	}
-
-	private final Controller.Type guessTypeFromComponents() throws IOException {
 		List components = getComponents();
 		if (components.size() == 0)
 			return Controller.Type.UNKNOWN;
@@ -342,15 +320,6 @@ final class LinuxEventDevice implements LinuxDevice {
 	}
 	private final static native void nGetBits(long fd, int ev_type, byte[] evtype_bits) throws IOException;
 
-	private final byte[] getDeviceUsageBits() throws IOException {
-		byte[] bits = new byte[NativeDefinitions.USAGE_MAX/8 + 1];
-		if (getVersion() >= 0x010001) {
-			nGetDeviceUsageBits(fd, bits);
-		}
-		return bits;
-	}
-	private final static native void nGetDeviceUsageBits(long fd, byte[] type_bits) throws IOException;
-
 	public final synchronized void pollKeyStates() throws IOException {
 		nGetKeyStates(fd, key_states);
 	}
@@ -390,6 +359,36 @@ final class LinuxEventDevice implements LinuxDevice {
 		if (closed)
 			throw new IOException("Device is closed");
 	}
+
+	private final static native int nGrab(long fd, int grab) throws IOException;
+
+	/**
+	 * Grabs the device so that no other programs can read from the device.
+	 */
+	public synchronized final boolean grab(){
+		try{
+			if(nGrab(fd,1) == 0){
+				return false;
+			}	
+		}catch(IOException e){
+			return false;
+		}
+		return true;
+	}
+	/**
+	 * Release the event so other programs can get events.
+	 */
+	public synchronized final boolean ungrab(){
+		try{
+			if(nGrab(fd,0) == 0){
+				return false;
+			}	
+		}catch(IOException e){
+			return false;
+		}
+		return true;
+	}
+
 
 	protected void finalize() throws IOException {
 		close();

--- a/plugins/linux/src/java/net/java/games/input/LinuxKeyboard.java
+++ b/plugins/linux/src/java/net/java/games/input/LinuxKeyboard.java
@@ -65,4 +65,8 @@ final class LinuxKeyboard extends Keyboard {
 	public final void pollDevice() throws IOException {
 		device.pollKeyStates();
 	}
+
+	public boolean grab(){ return device.grab(); }
+
+	public boolean ungrab(){ return device.ungrab();}
 }

--- a/plugins/linux/src/java/net/java/games/input/LinuxMouse.java
+++ b/plugins/linux/src/java/net/java/games/input/LinuxMouse.java
@@ -65,4 +65,8 @@ final class LinuxMouse extends Mouse {
 	protected final boolean getNextDeviceEvent(Event event) throws IOException {
 		return LinuxControllers.getNextDeviceEvent(event, device);
 	}
+
+	public boolean grab(){ return device.grab(); }
+
+	public boolean ungrab(){ return device.ungrab();}
 }

--- a/plugins/linux/src/native/net_java_games_input_LinuxEventDevice.c
+++ b/plugins/linux/src/native/net_java_games_input_LinuxEventDevice.c
@@ -112,20 +112,6 @@ JNIEXPORT jint JNICALL Java_net_java_games_input_LinuxEventDevice_nGetNumEffects
 	return num_effects;
 }
 
-JNIEXPORT void JNICALL Java_net_java_games_input_LinuxEventDevice_nGetDeviceUsageBits(JNIEnv *env, jclass unused, jlong fd_address, jbyteArray usages_array) {
-#if EV_VERSION >= 0x010001
-	int fd = (int)fd_address;
-	jsize len = (*env)->GetArrayLength(env, usages_array);
-	jbyte *usages = (*env)->GetByteArrayElements(env, usages_array, NULL);
-	if (usages == NULL)
-		return;
-	int res = ioctl(fd, EVIOCGUSAGE(len), usages);
-	(*env)->ReleaseByteArrayElements(env, usages_array, usages, 0);
-	if (res == -1)
-		throwIOException(env, "Failed to get device usages (%d)\n", errno);
-#endif
-}
-
 JNIEXPORT void JNICALL Java_net_java_games_input_LinuxEventDevice_nGetBits(JNIEnv *env, jclass unused, jlong fd_address, jint evtype, jbyteArray bits_array) {
 	int fd = (int)fd_address;
 	jsize len = (*env)->GetArrayLength(env, bits_array);
@@ -254,4 +240,19 @@ JNIEXPORT void JNICALL Java_net_java_games_input_LinuxEventDevice_nEraseEffect(J
 
 	if (ioctl(fd, EVIOCRMFF, &ff_id_int) == -1)
 		throwIOException(env, "Failed to erase effect (%d)\n", errno);
+}
+
+JNIEXPORT jint JNICALL Java_net_java_games_input_LinuxEventDevice_nGrab(JNIEnv *env, jclass unused, jlong fd_address, jint do_grab) {
+        int fd = (int)fd_address;
+        int grab = (int)do_grab;
+<<<<<<< HEAD
+        int version;
+        if (ioctl(fd,EVIOCGRAB,do_grab) == -1){
+=======
+        if (ioctl(fd,EVIOCGRAB,grab) == -1){
+>>>>>>> 835f3b36964d5a757ab4baea8240f1d56a97e375
+                throwIOException(env, "Failed to grab device (%d)\n", errno);
+            return -1;
+	}
+        return 1;
 }

--- a/plugins/linux/src/native/net_java_games_input_LinuxEventDevice.c
+++ b/plugins/linux/src/native/net_java_games_input_LinuxEventDevice.c
@@ -245,12 +245,7 @@ JNIEXPORT void JNICALL Java_net_java_games_input_LinuxEventDevice_nEraseEffect(J
 JNIEXPORT jint JNICALL Java_net_java_games_input_LinuxEventDevice_nGrab(JNIEnv *env, jclass unused, jlong fd_address, jint do_grab) {
         int fd = (int)fd_address;
         int grab = (int)do_grab;
-<<<<<<< HEAD
-        int version;
-        if (ioctl(fd,EVIOCGRAB,do_grab) == -1){
-=======
         if (ioctl(fd,EVIOCGRAB,grab) == -1){
->>>>>>> 835f3b36964d5a757ab4baea8240f1d56a97e375
                 throwIOException(env, "Failed to grab device (%d)\n", errno);
             return -1;
 	}


### PR DESCRIPTION
This is the first patch that prevents events from being forwarded to the operating system.  In order to make this patch work, I first had to fix a bug in an ant file that was apparently broken for compiling with java7 in linux.  After that I applied a patch which introduced a conflict (fixed in the last commit).  

I have tested with my jnostromo application and it seems to be working correctly.  

Note, there is another patch coming soon!
