### PR TITLE
Extend arrays to allow max ID value

### DIFF
--- a/plugins/linux/src/java/net/java/games/input/LinuxNativeTypesMap.java
+++ b/plugins/linux/src/java/net/java/games/input/LinuxNativeTypesMap.java
@@ -43,9 +43,9 @@ class LinuxNativeTypesMap {
     /** create an empty, uninitialsed map
      */    
     private LinuxNativeTypesMap() {
-        buttonIDs = new Component.Identifier[NativeDefinitions.KEY_MAX];
-        relAxesIDs = new Component.Identifier[NativeDefinitions.REL_MAX];
-        absAxesIDs = new Component.Identifier[NativeDefinitions.ABS_MAX];
+        buttonIDs = new Component.Identifier[NativeDefinitions.KEY_MAX + 1];
+        relAxesIDs = new Component.Identifier[NativeDefinitions.REL_MAX + 1];
+        absAxesIDs = new Component.Identifier[NativeDefinitions.ABS_MAX + 1];
 		reInit();
     }
     


### PR DESCRIPTION
The array was defined up to but not including the key value, it needs to include the max value to avoid out of bounds exceptions
